### PR TITLE
Add Player to manage clips at different times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9943,6 +9943,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "@testing-library/react": "^9.4.0",
         "@testing-library/user-event": "^7.2.1",
         "firebase": "^7.6.2",
+        "moment": "^2.24.0",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
         "react-router-dom": "^5.1.2",

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -1,0 +1,127 @@
+const _ = require('lodash')
+const moment = require('moment')
+
+const isBetween = (timeToCheck, startTime, endTime) => {
+    const timeFormat = 'mm:ss'
+    const start = moment(startTime, timeFormat)
+    const end = moment(endTime, timeFormat)
+
+    const time = moment(timeToCheck, timeFormat)
+
+    if (time.isBetween(start, end, 'seconds', '[)')) {
+        return true
+    }
+
+    return false
+}
+
+const pad = (num) => ('0' + num).slice(-2)
+const secondsToMinutes = (seconds) => {
+    let minutes = Math.floor(seconds / 60)
+    seconds = seconds % 60
+    // let hours = Math.floor(minutes / 60)
+    minutes = minutes % 60
+    return `${pad(minutes)}:${pad(seconds)}`
+    // return pad(hours)+":"+pad(minutes)+":"+pad(secs); for old browsers
+}
+
+const deriveActiveStatusForClips = (clips, timeToMatch) => {
+    _.each(clips, (clip) => {
+        const active = clip.startAt === timeToMatch
+        clip.active = active
+    })
+
+    return clips
+}
+
+export default class Player {
+    constructor(props) {
+        this.time = '00:00'
+        this.seconds = 0
+        this.allClips = deriveActiveStatusForClips(props.clips, this.time)
+        this.incrementSeconds = props.incrementSeconds
+
+        console.log('player', this)
+    }
+
+    play() {
+        const activeClips = _.filter(
+            this.allClips,
+            (clip) => clip.active === true
+        )
+        _.each(activeClips, (clip) => {
+            clip.videoRef.current.play()
+        })
+
+        this._startTimer()
+    }
+
+    pause() {
+        const activeClips = _.filter(
+            this.allClips,
+            (clip) => clip.active === true
+        )
+        _.each(activeClips, (clip) => {
+            clip.videoRef.current.pause()
+        })
+
+        this._stopTimer()
+    }
+
+    seek(newTime) {
+        this.time = newTime
+        this._updateActiveClips({ shouldPlay: true })
+    }
+
+    restart() {
+        this.seek(0)
+    }
+
+    _incrementTime(self) {
+        self.seconds = this.seconds + 1
+        self.time = secondsToMinutes(this.seconds)
+        self._updateActiveClips({ shouldPlay: true })
+        self.incrementSeconds(this.seconds)
+        console.log('tick', this)
+    }
+
+    _startTimer() {
+        this.timer = setInterval(() => this._incrementTime(this), 1000)
+    }
+
+    _stopTimer() {
+        clearInterval(this.timer)
+    }
+
+    _toggleActiveClip(clipId, isActive) {
+        const clip = _.find(this.allClips, (clip) => clip.clipId === clipId)
+        clip.active = isActive
+    }
+
+    _updateActiveClips({ shouldPlay }) {
+        // TODO: Use isBetween to determine the active clips, if the current time is past the endAt of a song,
+        // currently, it will start playing it when it should not be considered active.
+        const clipsToPlay = _.filter(
+            this.allClips,
+            (clip) => clip.startAt === this.time
+        )
+
+        _.each(clipsToPlay, (clip) => {
+            this._toggleActiveClip(clip.clipId, true)
+            if (shouldPlay) {
+                clip.videoRef.current.play()
+            }
+        })
+
+        const clipsToStop = _.filter(
+            this.allClips,
+            (clip) => clip.endAt === this.time
+        )
+
+        _.each(clipsToStop, (clip) => {
+            this._toggleActiveClip(clip.id, false)
+        })
+
+        return [clipsToPlay, clipsToStop]
+    }
+}

--- a/src/components/Track.js
+++ b/src/components/Track.js
@@ -3,9 +3,12 @@ import uuid from 'uuid/v4'
 import firebase from 'firebase/app'
 import styled from 'styled-components'
 
-import { Clip } from './index'
+const ClipVideo = styled.video`
+    width: 150px;
+    height: 100%;
+`
 
-const Track = ({ songId, id, track, addNewTrack }) => {
+const Track = ({ songId, id, track, clips, addNewTrack }) => {
     const videoInput = useRef(null)
 
     const onNameChange = (name) => {
@@ -35,10 +38,12 @@ const Track = ({ songId, id, track, addNewTrack }) => {
                 url: downloadURL,
             })
 
-        // Update track to include clip
-        const songRef = db.collection('songs').doc(songId)
-        const clipPath = `tracks.${id}.clips.${clipId}`
-        await songRef.update({ [clipPath]: { url: downloadURL } })
+        // Update song to include clip
+        const clipsRef = db
+            .collection('songs')
+            .doc(songId)
+            .collection('clips')
+        await clipsRef.add({ trackId: id, url: downloadURL, startAt: '00:00' })
     }
 
     const onDeleteTrack = async () => {
@@ -54,9 +59,6 @@ const Track = ({ songId, id, track, addNewTrack }) => {
             })
         }
     }
-
-    const clips = track?.clips
-    const clipIds = clips ? Object.keys(clips) : []
 
     return (
         <>
@@ -81,8 +83,10 @@ const Track = ({ songId, id, track, addNewTrack }) => {
                 className="rounded-md bg-gray-800 border-dashed border-gray-900 border-2"
                 style={{ height: '100px' }}
             >
-                {clipIds.length > 0 ? (
-                    <Clip id={clipIds[0]} />
+                {clips?.length > 0 ? (
+                    clips.map((clip) => (
+                        <ClipVideo key={clip.clipId} src={clip.url} />
+                    ))
                 ) : (
                     <div className="inline">
                         <input

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 export { default as Clip } from './Clip'
 export { default as LoginScreen } from './LoginScreen'
+export { default as Player } from './Player'
 export { default as PrivateRoute } from './PrivateRoute'
 export { default as PublicRoute } from './PublicRoute'
 export { default as Router } from './Router'


### PR DESCRIPTION
**This PR**

- Implements a `Player` that makes it possible to play different clips at different points in a song.
- Remodels the song structure to now have `clips` as a subcollection, instead of being nested under `tracks`
- Adds `moment` as a dependency

## New Song Structure
```
{
	id: "a4921b04-0bac-41b6-b50b-ef6b91b68137",
	title: "Fade to Black",
	createdBy: "16h21b04-0bac-41b6-b50b-ef6b91b683s8",
	tracks: {
		"a3s5dkfjas-ba7e-4553-a846-4384950d283": {
				title: "Guitar",
				enabled: true
		}
	},
	/* Clips subcollection */
}
```

## `Clips` Subcollection
```
{
    clipId: "a3s5dkfjas-ba7e-4553-a846-4384950d283",
    trackId: "zljshdf232s-sa7e-4553-a846-6584950d236",
    url: "https://firebasestorage.googleapis.com/v0/b/jams-b177f.appspot.com/o/clips%2Fb239f061-6135-419d-85b6-e2286555aeb9.mp4?alt=media&token=57f2f9b1-7f62-4e43-be2a-7dcdc9921142",
    startAt: "00:05",
    endAt: "00:10",
    length: "1:09",
}
```

With this PR merged, the app can do the following:
- Add tracks
- Add clips to tracks
- Add new track by recording
- Respond to `startAt` (if set in firebase console)
- Ticker and time update

Screenshot:
![image](https://user-images.githubusercontent.com/26389549/78108848-fe863980-73ac-11ea-881f-30fc85c92845.png)
